### PR TITLE
Allow aliases for actors on the flag page

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,6 @@
 use Mix.Config
 
 config :logger, level: :error
+
+config :fun_with_flags_ui, :flag_page,
+  alias_fn: {FunWithFlags.UI.FlagTransform, :flag_with_aliases}

--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -51,6 +51,11 @@ defmodule FunWithFlags.UI.Templates do
     |> Enum.join(", ")
   end
 
+  def gate_alias({_, target_alias}), do: target_alias
+  def gate_alias(target), do: target
+
+  def gate_for({target_for, _}), do: target_for
+  def gate_for(target), do: target
 
   def path(conn, path) do
     Path.join(conn.assigns[:namespace], path)

--- a/lib/fun_with_flags/ui/templates/rows/_actor.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_actor.html.eex
@@ -1,13 +1,13 @@
-<div id="actor_<%= @gate.for %>" class="container fwf-I-hate-grids">
+<div id="actor_<%= gate_for(@gate.for) %>" class="container fwf-I-hate-grids">
   <div class="row no-gutters">
     <div class="col-lg-8 col-md-7 col-sm-5 col-3 text-left">
-      <code><%= @gate.for %></code>
+      <code><%= gate_alias(@gate.for) %></code>
     </div>
     <div class="col-lg-2 col-md-2 col-sm-3 col-3 text-left">
       <%= html_status_for @gate.enabled %>
     </div>
     <div class="col-lg-1 col-md-2 col-sm-2 col-3 text-right">
-      <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{@gate.for}") %>" method="post" class="fwf-inline-toggle">
+      <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{gate_for(@gate.for)}") %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="PATCH">
 
         <%= if @gate.enabled do %>
@@ -20,9 +20,9 @@
       </form>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-2 col-3 text-right">
-      <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{@gate.for}") %>" method="post" class="float-right">
+      <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{gate_for(@gate.for)}") %>" method="post" class="float-right">
         <input type="hidden" name="_method" value="DELETE">
-        <button type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear actor '<%= @gate.for %>'?">Clear</button>
+        <button type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear actor '<%= gate_alias(@gate.for) %>'?">Clear</button>
       </form>
     </div>
   </div>

--- a/lib/fun_with_flags/ui/utils.ex
+++ b/lib/fun_with_flags/ui/utils.ex
@@ -69,8 +69,8 @@ defmodule FunWithFlags.UI.Utils do
   def get_flag(name) do
     if safe_flag_exists?(name) do
       case FunWithFlags.SimpleStore.lookup(String.to_existing_atom(name)) do
-        {:ok, _flag} = result ->
-          result
+        {:ok, flag} ->
+          {:ok, alias_targets(flag)}
         {:error, _reason} = error ->
           error
       end
@@ -149,6 +149,18 @@ defmodule FunWithFlags.UI.Utils do
   def sanitize(name) do
     name
     |> String.trim()
+  end
+
+  defp alias_targets(flag) do
+    config = Application.get_env(:fun_with_flags_ui, :flag_page, [])
+    alias_fn = Keyword.get(config, :alias_fn, nil)
+
+    case alias_fn do
+      {mod, fun} ->
+        apply(mod, fun, [flag])
+      _ ->
+        flag
+    end
   end
 
   def validate(name) do

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -103,12 +103,17 @@ defmodule FunWithFlags.UI.TemplatesTest do
     test "with actors and groups it contains their rows", %{conn: conn, flag: flag} do
       group_gate = %Gate{type: :group, for: :rocks, enabled: true}
       actor_gate = %Gate{type: :actor, for: "moss:123", enabled: true}
-      flag = %Flag{flag | gates: [actor_gate, group_gate]}
+      actor_gate_with_transform = %Gate{type: :actor, for: {"user:123", "User 123"}, enabled: true}
+      flag = %Flag{flag | gates: [actor_gate, actor_gate_with_transform, group_gate]}
 
       out = Templates.details(conn: conn, flag: flag)
 
       assert String.contains?(out, ~s{<div id="actor_moss:123"})
       assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:123" method="post"})
+
+      assert String.contains?(out, ~s{<div id="actor_user:123"})
+      assert String.contains?(out, ~s{User 123})
+      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/user:123" method="post"})
 
       assert String.contains?(out, ~s{<div id="group_rocks"})
       assert String.contains?(out, ~s{<form action="/pear/flags/avocado/groups/rocks" method="post"})

--- a/test/fun_with_flags/ui/utils_test.exs
+++ b/test/fun_with_flags/ui/utils_test.exs
@@ -2,6 +2,7 @@ defmodule FunWithFlags.UI.UtilsTest do
   use ExUnit.Case, async: true
 
   alias FunWithFlags.UI.Utils
+  alias FunWithFlags.UI.TestUser
   alias FunWithFlags.{Flag, Gate}
 
   import FunWithFlags.UI.TestUtils
@@ -76,6 +77,14 @@ defmodule FunWithFlags.UI.UtilsTest do
       FunWithFlags.enable(name, for_group: :berries)
 
       gate = Gate.new(:group, :berries, true)
+      assert {:ok, %Flag{name: ^name, gates: [^gate]}} = Utils.get_flag(to_string(name))
+    end
+
+    test "it transforms actor aliases" do
+      name = unique_atom()
+      FunWithFlags.enable(name, for_actor: %TestUser{id: 123})
+
+      gate = %Gate{type: :actor, for: {"user:123", "User 123"}, enabled: true}
       assert {:ok, %Flag{name: ^name, gates: [^gate]}} = Utils.get_flag(to_string(name))
     end
   end

--- a/test/support/flag_transform.ex
+++ b/test/support/flag_transform.ex
@@ -1,0 +1,11 @@
+defmodule FunWithFlags.UI.FlagTransform do
+  def flag_with_aliases(flag) do
+    gates = Enum.map(flag.gates, &gate_aliases/1)
+    %{flag | gates: gates}
+  end
+
+  defp gate_aliases(%{for: "user:" <> id} = gate) do
+    %{gate | for: {"user:#{id}", "User #{id}"}}
+  end
+  defp gate_aliases(gate), do: gate
+end

--- a/test/support/test_user.ex
+++ b/test/support/test_user.ex
@@ -1,0 +1,9 @@
+defmodule FunWithFlags.UI.TestUser do
+  defstruct [:id]
+end
+
+defimpl FunWithFlags.Actor, for: FunWithFlags.UI.TestUser do
+  def id(%{id: id}) do
+    "user:#{id}"
+  end
+end


### PR DESCRIPTION
Instead of having actors displayed in the format:

 * user:1
 * user:2
 * user:404
 * country:uk

Aliases allow a function to be called with the flag, which could fetch
the users names from the database and transform them into:

 * User Name 1
 * User Name 2
 * user:404
 * United Kingdom

This is achieved with the following (optional) config:

    config :fun_with_flags_ui, :flag_page,
      alias_fn: &MyApp.Feature.flag_alias/1

The function expects a `%FunWithFlags.Flag{}` struct, and returns a
`%FunWithFlags.Flag{}` struct.

An example (inefficient) implementation of the
`MyApp.Feature.flag_alias/1` function could be:

    def flag_alias(flag) do
      gates = Enum.map(flag.gates, &get_gate_aliases/1)
      %{flag | gates: gates}
    end

    defp get_gate_aliases(%{for: "user:" <> id} = gate) do
      case MyApp.Repo.get(MyApp.User, id) do
        nil -> gate
        user -> %{gate | for: {"account:" <> id, user.name}}
      end
    end
    defp get_gate_aliases(%{for: "country:uk"} = gate) do
      %{gate | for: {"country:uk", "United Kingdom"}}
    end
    defp get_gate_aliases(gate), do: gate

If the `for` is a 2-tuple, in the format `{:id, :display_name}` then the
`:id` will be used for all form actions (such as enable/disable) and the
`:display_name` field will be used when actually displaying the actor
row.

I chose to use a 2-tuple as it doesn't require any modification of the existing structs. One downside is that it does violate the typespec at https://github.com/tompave/fun_with_flags/blob/master/lib/fun_with_flags/gate.ex#L6