### PR TITLE
Fix compilation errors when forwarding to the UI.Router Plug

### DIFF
--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -27,12 +27,6 @@ defmodule FunWithFlags.UI.Router do
   plug :dispatch
 
   @doc false
-  def init(opts) do
-    Application.ensure_started(:fun_with_flags)
-    super(opts)
-  end
-
-  @doc false
   def call(conn, opts) do
     conn = extract_namespace(conn, opts)
     super(conn, opts)


### PR DESCRIPTION
Since Plug compiles the result of the `init` call at compile time, the call to
`Application.ensure_started(:fun_with_flags)` will be called at compile time.
This will attempt to start the fun_with_flags application and connect to the
PubSub adapter, however since the PubSub adapter doesn't run when the
application is compiling, the following output will be logged:

5 logs with:

> [debug] FunWithFlags: Cannot subscribe to Phoenix.PubSub...

Then an error log with:

 > [error] GenServer FunWithFlags.Notifications.PhoenixPubSub terminating
 > ** (RuntimeError) Tried to subscribe to Phoenix.PubSub process MyApp.PubSub
 > 5 times. Giving up.

This does not affect the compilation result, but it does cause a lot of noise.

Here's a sample script to reproduce the issue (when using an app generated with
Phoenix 1.3. This won't trigger on 1.4 and above as it does not use compile time
plug init in development).

```bash
echo yes | mix phx.new my_app --no-ecto --no-brunch
cd my_app

echo "config :fun_with_flags, :cache_bust_notifications, enabled: true,
    adapter: FunWithFlags.Notifications.PhoenixPubSub,
    client: MyApp.PubSub" >> config/config.exs

sed -i '36a\{:fun_with_flags_ui, "~> 0.4"},' mix.exs
sed -i '36a\{:redix, "~> 0.6"},' mix.exs

sed -i '21a\scope path: "/feature-flags" do \
forward "/", FunWithFlags.UI.Router \
end'  lib/my_app_web/router.ex

sed -i '2a\:timer.sleep 10_000' lib/my_app_web/controllers/page_controller.ex

mix deps.get && mix compile --force
```