### PR TITLE
Add csrf token to all forms

### DIFF
--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -23,6 +23,7 @@ defmodule FunWithFlags.UI.Router do
   plug Plug.Parsers, parsers: [:urlencoded]
   plug Plug.MethodOverride
 
+  plug :assign_csrf_token
   plug :match
   plug :dispatch
 
@@ -282,5 +283,11 @@ defmodule FunWithFlags.UI.Router do
   defp extract_namespace(conn, opts) do
     ns = opts[:namespace] || ""
     Plug.Conn.assign(conn, :namespace, "/" <> ns)
+  end
+
+
+  defp assign_csrf_token(conn, _opts) do
+    csrf_token = Plug.CSRFProtection.get_csrf_token()
+    Plug.Conn.assign(conn, :csrf_token, csrf_token)
   end
 end

--- a/lib/fun_with_flags/ui/templates/rows/_actor.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_actor.html.eex
@@ -9,6 +9,7 @@
     <div class="col-lg-1 col-md-2 col-sm-2 col-3 text-right">
       <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{@gate.for}") %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
 
         <%= if @gate.enabled do %>
           <input type="hidden" name="enabled" value="false">
@@ -22,6 +23,7 @@
     <div class="col-lg-1 col-md-1 col-sm-2 col-3 text-right">
       <form action="<%= path(@conn, "/flags/#{@flag.name}/actors/#{@gate.for}") %>" method="post" class="float-right">
         <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <button type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear actor '<%= @gate.for %>'?">Clear</button>
       </form>
     </div>

--- a/lib/fun_with_flags/ui/templates/rows/_boolean.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_boolean.html.eex
@@ -10,10 +10,11 @@
 <div class="card-block">
   <span class="fwf-global-flag-status">
     <%= html_status_for status %>
-  
+
     <%= if is_enabled or (status == :missing) do %>
       <form id="fwf-global-toggle-form" action="<%= form_path %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <input type="hidden" name="enabled" value="false">
         <button id="disable-boolean-btn" type="submit" class="btn btn-sm btn-outline-danger">Disable</button>
       </form>
@@ -22,6 +23,7 @@
     <%= if !is_enabled or (status == :missing) do %>
       <form id="fwf-global-toggle-form" action="<%= form_path %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <input type="hidden" name="enabled" value="true">
         <button id="enable-boolean-btn" type="submit" class="btn btn-sm btn-outline-success">Enable</button>
       </form>
@@ -30,6 +32,7 @@
     <%= unless status == :missing do %>
       <form action="<%= form_path %>" method="post" class="float-right">
         <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <button id="clear-boolean-btn" type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear the boolean gate? A missing boolean gate will be the same a as disabled boolean gate, and this option is provided mainly for debugging purposes.">Clear</button>
       </form>
     <% end %>

--- a/lib/fun_with_flags/ui/templates/rows/_group.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_group.html.eex
@@ -9,6 +9,7 @@
     <div class="col-lg-1 col-md-2 col-sm-2 col-3 text-right">
       <form action="<%= path(@conn, "/flags/#{@flag.name}/groups/#{@gate.for}") %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="PATCH">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
 
         <%= if @gate.enabled do %>
           <input type="hidden" name="enabled" value="false">
@@ -22,6 +23,7 @@
     <div class="col-lg-1 col-md-1 col-sm-2 col-3 text-right">
       <form action="<%= path(@conn, "/flags/#{@flag.name}/groups/#{@gate.for}") %>" method="post" class="fwf-inline-toggle">
         <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <button type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear group '<%= @gate.for %>'?">Clear</button>
       </form>
     </div>

--- a/lib/fun_with_flags/ui/templates/rows/_new_actor.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_new_actor.html.eex
@@ -1,5 +1,6 @@
 <span>
   <form id="fwf-new-actor-form" action="<%= path(@conn, "/flags/#{@flag.name}/actors") %>" method="post" class="form-inline">
+    <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
     <%= if assigns[:error_message] do %>
       <div class="input-group mr-2 has-danger fwf-wide-input">
         <div class="input-group-addon">actor ID</div>

--- a/lib/fun_with_flags/ui/templates/rows/_new_group.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_new_group.html.eex
@@ -1,5 +1,6 @@
 <span>
   <form id="fwf-new-group-form" action="<%= path(@conn, "/flags/#{@flag.name}/groups") %>" method="post" class="form-inline">
+    <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
     <%= if assigns[:error_message] do %>
       <div class="input-group mr-2 has-danger fwf-wide-input">
         <div class="input-group-addon">group name</div>

--- a/lib/fun_with_flags/ui/templates/rows/_percentage.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_percentage.html.eex
@@ -20,6 +20,7 @@
     <div class="col-lg-1 col-md-1 col-sm-2 col-3 text-right">
       <form action="<%= path(@conn, "/flags/#{@flag.name}/percentage") %>" method="post" class="float-right">
         <input type="hidden" name="_method" value="DELETE">
+        <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
         <button type="submit" class="btn btn-sm btn-secondary" data-confirm="Are you sure you want to clear the '<%= human_name %>' gate?">Clear</button>
       </form>
     </div>

--- a/lib/fun_with_flags/ui/templates/rows/_percentage_form.html.eex
+++ b/lib/fun_with_flags/ui/templates/rows/_percentage_form.html.eex
@@ -3,6 +3,7 @@
 %>
 <span>
   <form id="fwf-new-group-form" action="<%= path(@conn, "/flags/#{@flag.name}/percentage") %>" method="post" class="form-inline">
+    <input type="hidden" name="_csrf_token" value="<%= @conn.assigns[:csrf_token] %>">
     <%= if assigns[:error_message] do %>
       <div class="input-group mr-2 has-danger fwf-wide-input">
         <div class="input-group-addon">percentage</div>

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -13,6 +13,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
 
   setup do
     conn = Plug.Conn.assign(%Plug.Conn{}, :namespace, "/pear")
+    conn = Plug.Conn.assign(conn, :csrf_token, Plug.CSRFProtection.get_csrf_token())
     {:ok, conn: conn}
   end
 
@@ -71,6 +72,12 @@ defmodule FunWithFlags.UI.TemplatesTest do
       assert String.contains?(out, "<title>FunWithFlags - avocado</title>")
       assert String.contains?(out, ~s{<a href="/pear/new" class="btn btn-secondary">New Flag</a>})
       assert String.contains?(out, "<h1>avocado</h1>")
+    end
+
+    test "it includes the CSRF token", %{conn: conn, flag: flag} do
+      csrf_token = Plug.CSRFProtection.get_csrf_token()
+      out = Templates.details(conn: conn, flag: flag)
+      assert String.contains?(out, ~s{<input type="hidden" name="_csrf_token" value="#{csrf_token}">})
     end
 
     test "it includes the global toggle, the new actor and new group forms, and the global delete form", %{conn: conn, flag: flag} do


### PR DESCRIPTION
Closes #3 

Adds CSRF support to all forms. 

I was a little torn on how to make this token accessible in the view. I ended up opting to put it in `conn.assigns` rather than explicitly passing it into `Template.details` and then down through all the partials. The reason for this was because this would require changing a lot of files and pretty much every template test. If this _is_ the preferred route to go though, I can update the PR to work that way.

I also wasn't sure the best way to put in a test for this, so I just added a test ensuring that the CSRF token was on the page. I also didn't put any tests around `:protect_from_forgery` because it felt outside of the scope of this project. I would expect the app implementing this package would handle this. I _did_ test using this build of the package in an app that I am working on both with and without `:protect_from_forgery` and it worked fine both ways (so sending up the csrf token is not a problem even if the protect is not on).

Please let me know if there's anything that needs to be changed or updated!