### PR TITLE
Adds protect from forgery to non-static routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ defmodule MyPhoenixApp.Web.Router do
 end
 ```
 
->Note: There is no need to `:protect_from_forgery` as this package already implements CSRF protection. 
+>Note: There is no need to `:protect_from_forgery` as this package already implements CSRF protection if you're host application uses the session plug. 
 
 ### Mounted in another Plug application
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ defmodule MyPhoenixApp.Web.Router do
   pipeline :mounted_apps do
     plug :accepts, ["html"]
     plug :put_secure_browser_headers
-    plug :protect_from_forgery
   end
 
   scope path: "/feature-flags" do
@@ -33,6 +32,8 @@ defmodule MyPhoenixApp.Web.Router do
   end
 end
 ```
+
+>Note: There is no need to `:protect_from_forgery` as this package already implements CSRF protection. 
 
 ### Mounted in another Plug application
 

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -300,7 +300,7 @@ defmodule FunWithFlags.UI.Router do
       |> fetch_session()
       |> Plug.CSRFProtection.call(Plug.CSRFProtection.init(opts))
     rescue
-      _e in Plug.CSRFProtection.InvalidCrossOriginRequestError ->
+      _e in ArgumentError ->
         Logger.warn("CSRF forgery protection won't work unless your host application uses the session plug")
         conn
       error ->

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -20,6 +20,8 @@ defmodule FunWithFlags.UI.Router do
     at: "/assets",
     from: :fun_with_flags_ui
 
+  plug :protect_from_forgery
+
   plug Plug.Parsers, parsers: [:urlencoded]
   plug Plug.MethodOverride
 
@@ -289,5 +291,10 @@ defmodule FunWithFlags.UI.Router do
   defp assign_csrf_token(conn, _opts) do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
     Plug.Conn.assign(conn, :csrf_token, csrf_token)
+  end
+
+
+  defp protect_from_forgery(conn, opts \\ []) do
+    Plug.CSRFProtection.call(conn, Plug.CSRFProtection.init(opts))
   end
 end

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -303,8 +303,6 @@ defmodule FunWithFlags.UI.Router do
       _e in ArgumentError ->
         Logger.warn("CSRF forgery protection won't work unless your host application uses the session plug")
         conn
-      error ->
-        reraise(error, __STACKTRACE__)
     end
   end
 end

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -20,7 +20,8 @@ defmodule FunWithFlags.UI.Router do
     at: "/assets",
     from: :fun_with_flags_ui
 
-  plug :protect_from_forgery
+  plug :fetch_session
+  plug Plug.CSRFProtection
 
   plug Plug.Parsers, parsers: [:urlencoded]
   plug Plug.MethodOverride
@@ -291,10 +292,5 @@ defmodule FunWithFlags.UI.Router do
   defp assign_csrf_token(conn, _opts) do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
     Plug.Conn.assign(conn, :csrf_token, csrf_token)
-  end
-
-
-  defp protect_from_forgery(conn, opts \\ []) do
-    Plug.CSRFProtection.call(conn, Plug.CSRFProtection.init(opts))
   end
 end

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -4,7 +4,7 @@ defmodule FunWithFlags.UI.Router do
 
   See the [Readme](/fun_with_flags_ui/readme.html#how-to-run) for more detailed instructions.
   """
-
+  require Logger
   use Plug.Router
   alias FunWithFlags.UI.{Templates, Utils}
   alias FunWithFlags.UI.SimpleActor
@@ -20,8 +20,7 @@ defmodule FunWithFlags.UI.Router do
     at: "/assets",
     from: :fun_with_flags_ui
 
-  plug :fetch_session
-  plug Plug.CSRFProtection
+  plug :protect_from_forgery
 
   plug Plug.Parsers, parsers: [:urlencoded]
   plug Plug.MethodOverride
@@ -292,5 +291,18 @@ defmodule FunWithFlags.UI.Router do
   defp assign_csrf_token(conn, _opts) do
     csrf_token = Plug.CSRFProtection.get_csrf_token()
     Plug.Conn.assign(conn, :csrf_token, csrf_token)
+  end
+
+
+  defp protect_from_forgery(conn, opts) do
+    try do
+      conn
+      |> fetch_session()
+      |> Plug.CSRFProtection.call(Plug.CSRFProtection.init(opts))
+    rescue
+      _error ->
+        Logger.warn("CSRF forgery protection won't work unless your host application uses the session plug")
+        conn
+    end
   end
 end

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -300,9 +300,11 @@ defmodule FunWithFlags.UI.Router do
       |> fetch_session()
       |> Plug.CSRFProtection.call(Plug.CSRFProtection.init(opts))
     rescue
-      _error ->
+      _e in Plug.CSRFProtection.InvalidCrossOriginRequestError ->
         Logger.warn("CSRF forgery protection won't work unless your host application uses the session plug")
         conn
+      error ->
+        reraise(error, __STACKTRACE__)
     end
   end
 end


### PR DESCRIPTION
Closes issue #5 

Moved the `protect_from_forgery` plug into this package so that we can add it to all routes _except_ the static routes. This will allow the front end to make a get request for the JS file and not get denied.

I also updated the readme to indicate that adding `protect_from_forgery` around these routes is no longer needed. 

I don't _love_ this solution, but it's the best solution I can come up with right now. I'm happy to make changes if there are thoughts on better ways to handle this. 