### PR TITLE
Order gates

### DIFF
--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -52,11 +52,21 @@ defmodule FunWithFlags.UI.Templates do
     end
   end
 
+  @gate_type_order [
+    :boolean,
+    :actor,
+    :group,
+    :percentage_of_actors,
+    :percentage_of_time,
+  ]
+  |> Enum.with_index()
+  |> Map.new()
 
   def html_gate_list(%Flag{gates: gates}) do
     gates
     |> Enum.map(&(&1.type))
     |> Enum.uniq()
+    |> Enum.sort_by(&Map.get(@gate_type_order, &1, 99))
     |> Enum.join(", ")
   end
 


### PR DESCRIPTION
I opted for only ordering gates only as part of their formatting. I'm not sure if it would really be useful to order the gates in the flags themselves.