### PR TITLE
Removed namespace option

### DIFF
--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -29,12 +29,6 @@ defmodule FunWithFlags.UI.Router do
   plug :match
   plug :dispatch
 
-  @doc false
-  def call(conn, opts) do
-    conn = extract_namespace(conn, opts)
-    super(conn, opts)
-  end
-
 
   get "/" do
     conn
@@ -273,18 +267,12 @@ defmodule FunWithFlags.UI.Router do
 
 
   defp redirect_to(conn, uri) do
-    path = Path.join(conn.assigns[:namespace], uri)
+    path = Path.join(Templates.base_path(conn), uri)
 
     conn
     |> put_resp_header("location", path)
     |> put_resp_content_type("text/html")
     |> send_resp(302, "<html><body>You are being <a href=\"#{path}\">redirected</a>.</body></html>")
-  end
-
-
-  defp extract_namespace(conn, opts) do
-    ns = opts[:namespace] || ""
-    Plug.Conn.assign(conn, :namespace, "/" <> ns)
   end
 
 
@@ -297,7 +285,7 @@ defmodule FunWithFlags.UI.Router do
   # Custom CSRF protection plug. It wraps the default plug provided
   # by `Plug`, it calls `Plug.Conn.fetch_session/1` (no-op if already
   # fetched), and it bails out gracefully if no session is configured.
-  # 
+  #
   defp protect_from_forgery(conn, opts) do
     try do
       conn

--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -72,6 +72,14 @@ defmodule FunWithFlags.UI.Templates do
 
 
   def path(conn, path) do
-    Path.join(conn.assigns[:namespace], path)
+    Path.join(base_path(conn), path)
+  end
+
+
+  # https://github.com/thoughtbot/bamboo/blob/master/lib/bamboo/plug/sent_email_viewer/email_preview_plug.ex#L107
+  def base_path(%{script_name: []}), do: ""
+
+  def base_path(%{script_name: script_name}) do
+    "/" <> Enum.join(script_name, "/")
   end
 end

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -12,8 +12,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
   end
 
   setup do
-    conn = Plug.Conn.assign(%Plug.Conn{}, :namespace, "/pear")
-    conn = Plug.Conn.assign(conn, :csrf_token, Plug.CSRFProtection.get_csrf_token())
+    conn = Plug.Conn.assign(%Plug.Conn{}, :csrf_token, Plug.CSRFProtection.get_csrf_token())
     {:ok, conn: conn}
   end
 
@@ -27,7 +26,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
     test "it includes the right content", %{conn: conn} do
       out = Templates._head(conn: conn, title: "Coconut")
       assert String.contains?(out, "<title>FunWithFlags - Coconut</title>")
-      assert String.contains?(out, ~s{href="/pear/assets/style.css"})
+      assert String.contains?(out, ~s{href="/assets/style.css"})
     end
   end
 
@@ -49,9 +48,9 @@ defmodule FunWithFlags.UI.TemplatesTest do
     test "it includes the right content", %{conn: conn, flags: flags} do
       out = Templates.index(conn: conn, flags: flags)
       assert String.contains?(out, "<title>FunWithFlags - List</title>")
-      assert String.contains?(out, ~s{<a href="/pear/new" class="btn btn-secondary">New Flag</a>})
-      assert String.contains?(out, ~s{<a href="/pear/flags/pineapple">pineapple</a>})
-      assert String.contains?(out, ~s{<a href="/pear/flags/papaya">papaya</a>})
+      assert String.contains?(out, ~s{<a href="/new" class="btn btn-secondary">New Flag</a>})
+      assert String.contains?(out, ~s{<a href="/flags/pineapple">pineapple</a>})
+      assert String.contains?(out, ~s{<a href="/flags/papaya">papaya</a>})
     end
   end
 
@@ -70,7 +69,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
     test "it includes the right content", %{conn: conn, flag: flag} do
       out = Templates.details(conn: conn, flag: flag)
       assert String.contains?(out, "<title>FunWithFlags - avocado</title>")
-      assert String.contains?(out, ~s{<a href="/pear/new" class="btn btn-secondary">New Flag</a>})
+      assert String.contains?(out, ~s{<a href="/new" class="btn btn-secondary">New Flag</a>})
       assert String.contains?(out, "<h1>avocado</h1>")
     end
 
@@ -82,10 +81,10 @@ defmodule FunWithFlags.UI.TemplatesTest do
 
     test "it includes the global toggle, the new actor and new group forms, and the global delete form", %{conn: conn, flag: flag} do
       out = Templates.details(conn: conn, flag: flag)
-      assert String.contains?(out, ~s{<form id="fwf-global-toggle-form" action="/pear/flags/avocado/boolean" method="post"})
-      assert String.contains?(out, ~s{<form id="fwf-new-actor-form" action="/pear/flags/avocado/actors" method="post"})
-      assert String.contains?(out, ~s{<form id="fwf-new-group-form" action="/pear/flags/avocado/groups" method="post"})
-      assert String.contains?(out, ~s{<form id="fwf-delete-flag-form" action="/pear/flags/avocado" method="post">})
+      assert String.contains?(out, ~s{<form id="fwf-global-toggle-form" action="/flags/avocado/boolean" method="post"})
+      assert String.contains?(out, ~s{<form id="fwf-new-actor-form" action="/flags/avocado/actors" method="post"})
+      assert String.contains?(out, ~s{<form id="fwf-new-group-form" action="/flags/avocado/groups" method="post"})
+      assert String.contains?(out, ~s{<form id="fwf-delete-flag-form" action="/flags/avocado" method="post">})
     end
 
     test "with no boolean gate, it includes both the enabled and disable boolean buttons", %{conn: conn, flag: flag} do
@@ -139,10 +138,10 @@ defmodule FunWithFlags.UI.TemplatesTest do
       out = Templates.details(conn: conn, flag: flag)
 
       assert String.contains?(out, ~s{<div id="actor_moss:123"})
-      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:123" method="post"})
+      assert String.contains?(out, ~s{<form action="/flags/avocado/actors/moss:123" method="post"})
 
       assert String.contains?(out, ~s{<div id="group_rocks"})
-      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/groups/rocks" method="post"})
+      assert String.contains?(out, ~s{<form action="/flags/avocado/groups/rocks" method="post"})
     end
   end
 
@@ -156,7 +155,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
     test "it includes the right content", %{conn: conn} do
       out = Templates.new(conn: conn)
       assert String.contains?(out, "<title>FunWithFlags - New Flag</title>")
-      assert String.contains?(out, ~s{<form id="new-flag-form" action="/pear/flags" method="post">})
+      assert String.contains?(out, ~s{<form id="new-flag-form" action="/flags" method="post">})
     end
   end
 


### PR DESCRIPTION
Closes #12 

I could not get this plug to work without these changes as the redirects were really unexpected, especially when hosting the application in a nested route.

If I add the following line to my Plug.Router at _/api/admin_:
`forward "/fun_with_flags", to: FunWithFlags.UI.Router`

The fun with flags endpoint will automatically be available at _/api/admin/fun_with_flags_

**Some notes:**

- I was **not** able to **run the unit tests** since I do not have a Redis instance. I adjusted them the best I could but you probably will want to run them yourself before merging this.
- This is most likely a **breaking change**, requiring a major version upgrade if you follow SemVer
- I did **not test** this with **Phoenix** as I do not use Phoenix, only raw Plug with Ecto.

I might follow up with a smaller unrelated PR later, but this is a really important change for me.

Thank you for your time and I apologize for the inconvenience of you having to test my PR :)
