### PR TITLE
Use Logger.warning/2

### DIFF
--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -304,7 +304,7 @@ defmodule FunWithFlags.UI.Router do
       |> Plug.CSRFProtection.call(opts)
     rescue
       _e in ArgumentError ->
-        Logger.warn("CSRF protection won't work unless your host application uses the session plug")
+        Logger.warning("CSRF protection won't work unless your host application uses the session plug")
         conn
     end
   end


### PR DESCRIPTION
Remove the `Logger.warn/2` in favor of `Logger.warning/2`

Reference: https://hexdocs.pm/logger/main/Logger.html#warn/2