### PR TITLE
Support for slash in group name

### DIFF
--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -80,6 +80,6 @@ defmodule FunWithFlags.UI.Templates do
   def url_safe(val) do
     val
     |> to_string()
-    |> URI.encode()
+    |> URI.encode(fn (c) -> c != ?/ and URI.char_unescaped?(c) end)
   end
 end

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -18,6 +18,16 @@ defmodule FunWithFlags.UI.TemplatesTest do
   end
 
 
+  describe "url_safe" do
+    test "it escapes / character" do
+      assert Templates.url_safe("/") == "%2F"
+    end
+
+    test "it escapes { character" do
+      assert Templates.url_safe("{") == "%7B"
+    end
+  end
+
   describe "_head()" do
     test "it renders", %{conn: conn} do
       out = Templates._head(conn: conn, title: "Coconut")
@@ -153,7 +163,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
       out = Templates.details(conn: conn, flag: flag)
 
       assert String.contains?(out, ~s{<div id="actor_moss:&lt;h1&gt;123&lt;/h1&gt;"})
-      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:%3Ch1%3E123%3C/h1%3E" method="post"})
+      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:%3Ch1%3E123%3C%2Fh1%3E" method="post"})
 
       assert String.contains?(out, ~s{<div id="group_rocks"})
       assert String.contains?(out, ~s{<form action="/pear/flags/avocado/groups/rocks" method="post"})


### PR DESCRIPTION
Encode slash as %2F. If group name contained a `/` character then this would be interpreted by phoenix router as a different path segment. I'm not sure if this works across all browsers or network setups because maybe some browsers will unescape values in the path before submitting the path or middle boxes might rewrite the path to an unescaped form.

I'm also not sure what other characters would cause the functionality to break. 

Alternatively, the UI should ban you from creating flags with characters it does not support. However, I'm not sure that this is realistic because the non-ui part of the project does not put any restriction on the characters that can be contained in a name.