### PR TITLE
fix: disallow URL unsafe inputs

### DIFF
--- a/lib/fun_with_flags/ui/utils.ex
+++ b/lib/fun_with_flags/ui/utils.ex
@@ -160,16 +160,18 @@ defmodule FunWithFlags.UI.Utils do
 
   def validate(name) do
     string = to_string(name)
+
     cond do
       blank?(string) ->
         {:fail, "can't be blank"}
-      String.match?(string, ~r/\?/) ->
-        {:fail, "includes invalid characters: '?'"}
+
+      string |> String.to_charlist() |> Enum.any?(&URI.char_reserved?/1) ->
+        {:fail, "includes URI reserved characters"}
+
       true ->
         :ok
     end
   end
-
 
   def parse_and_validate_float(string) do
     if blank?(string) do

--- a/test/fun_with_flags/ui/utils_test.exs
+++ b/test/fun_with_flags/ui/utils_test.exs
@@ -200,21 +200,22 @@ defmodule FunWithFlags.UI.UtilsTest do
     end
   end
 
-
   describe "sanitize(name)" do
     test "it removes leading and trailing whitespace" do
       assert "apricot" = Utils.sanitize(" apricot   ")
     end
   end
 
-
   describe "validate(name)" do
     test "it returns {:fail, reason} for blank values" do
       assert {:fail, "can't be blank"} = Utils.validate(:"")
     end
 
-    test "it returns {:fail, reason} for values with question marks" do
-      assert {:fail, "includes invalid characters: '?'"} = Utils.validate(:banana?)
+    test "it returns {:fail, reason} for values with URI reserved characters" do
+      assert {:fail, "includes URI reserved characters"} = Utils.validate(:banana?)
+      assert {:fail, "includes URI reserved characters"} = Utils.validate(:"ban/ana")
+      assert {:fail, "includes URI reserved characters"} = Utils.validate(:"ban#ana")
+      assert {:fail, "includes URI reserved characters"} = Utils.validate(:"ban&ana")
     end
 
     test "it returns :ok otherwise" do


### PR DESCRIPTION
See https://github.com/tompave/fun_with_flags_ui/pull/36

My team ran onto this exact issue by accident—someone accidentally created a group name with URL reserved chars (specifically `/`) in it, and because the `url_safe` function does not escape these, it winds up creating a bogus URL in the template.

In my ideal world the solution in the linked PR above would be accepted, but given the conversation on that PR, that seems like it's not going to happen, so this at least validates that unsafe inputs can't be used to create a group or flag name.