### PR TITLE
fix: percent-encode reserved chars in actor/group gate URLs

### DIFF
--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -141,7 +141,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_actor: actor)
     end
 
-    redirect_to conn, "/flags/#{name}#actor_#{Templates.url_safe(actor_id)}"
+    redirect_to conn, "/flags/#{name}#actor_#{Utils.url_safe(actor_id)}"
   end
 
 
@@ -169,7 +169,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_group: group_name)
     end
 
-    redirect_to conn, "/flags/#{name}#group_#{Templates.url_safe(group_name)}"
+    redirect_to conn, "/flags/#{name}#group_#{Utils.url_safe(group_name)}"
   end
 
 
@@ -209,7 +209,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_actor: actor)
         end
-        redirect_to conn, "/flags/#{name}#actor_#{Templates.url_safe(actor_id)}"
+        redirect_to conn, "/flags/#{name}#actor_#{Utils.url_safe(actor_id)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, actor_error_message: "The actor ID #{reason}.")
@@ -232,7 +232,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_group: group_name)
         end
-        redirect_to conn, "/flags/#{name}#group_#{Templates.url_safe(group_name)}"
+        redirect_to conn, "/flags/#{name}#group_#{Utils.url_safe(group_name)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, group_error_message: "The group name #{reason}.")

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -141,7 +141,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_actor: actor)
     end
 
-    redirect_to conn, "/flags/#{name}#actor_#{actor_id}"
+    redirect_to conn, "/flags/#{name}#actor_#{encode_segment(actor_id)}"
   end
 
 
@@ -169,7 +169,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_group: group_name)
     end
 
-    redirect_to conn, "/flags/#{name}#group_#{group_name}"
+    redirect_to conn, "/flags/#{name}#group_#{encode_segment(group_name)}"
   end
 
 
@@ -209,7 +209,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_actor: actor)
         end
-        redirect_to conn, "/flags/#{name}#actor_#{actor_id}"
+        redirect_to conn, "/flags/#{name}#actor_#{encode_segment(actor_id)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, actor_error_message: "The actor ID #{reason}.")
@@ -232,7 +232,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_group: group_name)
         end
-        redirect_to conn, "/flags/#{name}#group_#{group_name}"
+        redirect_to conn, "/flags/#{name}#group_#{encode_segment(group_name)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, group_error_message: "The group name #{reason}.")
@@ -278,6 +278,13 @@ defmodule FunWithFlags.UI.Router do
     |> put_resp_header("location", path)
     |> put_resp_content_type("text/html")
     |> send_resp(302, "<html><body>You are being <a href=\"#{path}\">redirected</a>.</body></html>")
+  end
+
+
+  defp encode_segment(value) do
+    value
+    |> to_string()
+    |> URI.encode(&URI.char_unreserved?/1)
   end
 
 

--- a/lib/fun_with_flags/ui/router.ex
+++ b/lib/fun_with_flags/ui/router.ex
@@ -141,7 +141,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_actor: actor)
     end
 
-    redirect_to conn, "/flags/#{name}#actor_#{encode_segment(actor_id)}"
+    redirect_to conn, "/flags/#{name}#actor_#{Templates.url_safe(actor_id)}"
   end
 
 
@@ -169,7 +169,7 @@ defmodule FunWithFlags.UI.Router do
       FunWithFlags.disable(flag_name, for_group: group_name)
     end
 
-    redirect_to conn, "/flags/#{name}#group_#{encode_segment(group_name)}"
+    redirect_to conn, "/flags/#{name}#group_#{Templates.url_safe(group_name)}"
   end
 
 
@@ -209,7 +209,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_actor: actor)
         end
-        redirect_to conn, "/flags/#{name}#actor_#{encode_segment(actor_id)}"
+        redirect_to conn, "/flags/#{name}#actor_#{Templates.url_safe(actor_id)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, actor_error_message: "The actor ID #{reason}.")
@@ -232,7 +232,7 @@ defmodule FunWithFlags.UI.Router do
         else
           FunWithFlags.disable(flag_name, for_group: group_name)
         end
-        redirect_to conn, "/flags/#{name}#group_#{encode_segment(group_name)}"
+        redirect_to conn, "/flags/#{name}#group_#{Templates.url_safe(group_name)}"
       {:fail, reason} ->
         {:ok, flag} = Utils.get_flag(name)
         body = Templates.details(conn: conn, flag: flag, group_error_message: "The group name #{reason}.")
@@ -278,13 +278,6 @@ defmodule FunWithFlags.UI.Router do
     |> put_resp_header("location", path)
     |> put_resp_content_type("text/html")
     |> send_resp(302, "<html><body>You are being <a href=\"#{path}\">redirected</a>.</body></html>")
-  end
-
-
-  defp encode_segment(value) do
-    value
-    |> to_string()
-    |> URI.encode(&URI.char_unreserved?/1)
   end
 
 

--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -80,6 +80,6 @@ defmodule FunWithFlags.UI.Templates do
   def url_safe(val) do
     val
     |> to_string()
-    |> URI.encode()
+    |> URI.encode(&URI.char_unreserved?/1)
   end
 end

--- a/lib/fun_with_flags/ui/templates.ex
+++ b/lib/fun_with_flags/ui/templates.ex
@@ -5,6 +5,7 @@ defmodule FunWithFlags.UI.Templates do
   alias FunWithFlags.Flag
   alias FunWithFlags.UI.Utils
   import FunWithFlags.UI.HTMLEscape, only: [html_escape: 1]
+  import FunWithFlags.UI.Utils, only: [url_safe: 1]
 
   @templates [
     _head: "_head",
@@ -77,9 +78,4 @@ defmodule FunWithFlags.UI.Templates do
   end
 
 
-  def url_safe(val) do
-    val
-    |> to_string()
-    |> URI.encode(&URI.char_unreserved?/1)
-  end
 end

--- a/lib/fun_with_flags/ui/utils.ex
+++ b/lib/fun_with_flags/ui/utils.ex
@@ -158,6 +158,12 @@ defmodule FunWithFlags.UI.Utils do
     |> String.trim()
   end
 
+  def url_safe(val) do
+    val
+    |> to_string()
+    |> URI.encode(&URI.char_unreserved?/1)
+  end
+
   def validate(name) do
     string = to_string(name)
     cond do

--- a/test/fun_with_flags/ui/router_test.exs
+++ b/test/fun_with_flags/ui/router_test.exs
@@ -200,6 +200,77 @@ defmodule FunWithFlags.UI.RouterTest do
   end
 
 
+  describe "gates with '/' in the for value" do
+    # Actor ids and group names are free-text input through the admin form and
+    # only filter `?` via Utils.validate/1, so they can legitimately contain `/`.
+
+    setup do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one)
+      :ok
+    end
+
+    test "PATCH /flags/:name/actors/<encoded> toggles the actor gate and redirects with an encoded actor id" do
+      {:ok, true} =
+        FunWithFlags.enable(:test_flag_one, for_actor: %FunWithFlags.UI.SimpleActor{id: "w:foo/bar"})
+
+      conn =
+        decoded_request!(
+          :patch,
+          "/flags/test_flag_one/actors/w%3Afoo%2Fbar",
+          ["flags", "test_flag_one", "actors", "w:foo/bar"],
+          %{enabled: "false"}
+        )
+
+      assert 302 = conn.status
+      assert ["/flags/test_flag_one#actor_w%3Afoo%2Fbar"] = get_resp_header(conn, "location")
+    end
+
+    test "DELETE /flags/:name/actors/<encoded> clears the actor gate and redirects" do
+      {:ok, true} =
+        FunWithFlags.enable(:test_flag_one, for_actor: %FunWithFlags.UI.SimpleActor{id: "w:foo/bar"})
+
+      conn =
+        decoded_request!(
+          :delete,
+          "/flags/test_flag_one/actors/w%3Afoo%2Fbar",
+          ["flags", "test_flag_one", "actors", "w:foo/bar"]
+        )
+
+      assert 302 = conn.status
+      assert ["/flags/test_flag_one#actor_gates"] = get_resp_header(conn, "location")
+    end
+
+    test "PATCH /flags/:name/groups/<encoded> toggles the group gate and redirects with an encoded group name" do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one, for_group: "tenants/eu")
+
+      conn =
+        decoded_request!(
+          :patch,
+          "/flags/test_flag_one/groups/tenants%2Feu",
+          ["flags", "test_flag_one", "groups", "tenants/eu"],
+          %{enabled: "false"}
+        )
+
+      assert 302 = conn.status
+      assert ["/flags/test_flag_one#group_tenants%2Feu"] = get_resp_header(conn, "location")
+    end
+
+    test "DELETE /flags/:name/groups/<encoded> clears the group gate and redirects" do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one, for_group: "tenants/eu")
+
+      conn =
+        decoded_request!(
+          :delete,
+          "/flags/test_flag_one/groups/tenants%2Feu",
+          ["flags", "test_flag_one", "groups", "tenants/eu"]
+        )
+
+      assert 302 = conn.status
+      assert ["/flags/test_flag_one#group_gates"] = get_resp_header(conn, "location")
+    end
+  end
+
+
   # For GET and DELETE
   #
   defp request!(method, path) do
@@ -217,6 +288,23 @@ defmodule FunWithFlags.UI.RouterTest do
   defp request!(method, path, params) when is_map(params) do
     conn(method, path, Plug.Conn.Query.encode(params))
     |> put_req_header("content-type", "application/x-www-form-urlencoded")
+    |> Router.call(@opts)
+  end
+
+  # Plug.Test's conn/3 does not URL-decode each path segment the way the real
+  # Cowboy/Bandit adapters do, so a path like `/flags/feature%2Ffoo` ends up in
+  # `path_info` as `["flags", "feature%2Ffoo"]` instead of `["flags", "feature/foo"]`.
+  # We simulate the real adapter by overriding `path_info` after building the conn.
+  defp decoded_request!(method, path, path_info) do
+    conn(method, path)
+    |> Map.put(:path_info, path_info)
+    |> Router.call(@opts)
+  end
+
+  defp decoded_request!(method, path, path_info, params) when is_map(params) do
+    conn(method, path, Plug.Conn.Query.encode(params))
+    |> put_req_header("content-type", "application/x-www-form-urlencoded")
+    |> Map.put(:path_info, path_info)
     |> Router.call(@opts)
   end
 end

--- a/test/fun_with_flags/ui/router_test.exs
+++ b/test/fun_with_flags/ui/router_test.exs
@@ -296,10 +296,8 @@ defmodule FunWithFlags.UI.RouterTest do
     |> Router.call(@opts)
   end
 
-  # Plug.Test's conn/3 does not URL-decode each path segment the way the real
-  # Cowboy/Bandit adapters do, so a path like `/flags/feature%2Ffoo` ends up in
-  # `path_info` as `["flags", "feature%2Ffoo"]` instead of `["flags", "feature/foo"]`.
-  # We simulate the real adapter by overriding `path_info` after building the conn.
+  # Plug.Test doesn't URL-decode path segments like real adapters do,
+  # so we override path_info to simulate Cowboy/Bandit behavior.
   defp decoded_request!(method, path, path_info) do
     conn(method, path)
     |> Map.put(:path_info, path_info)

--- a/test/fun_with_flags/ui/router_test.exs
+++ b/test/fun_with_flags/ui/router_test.exs
@@ -200,16 +200,9 @@ defmodule FunWithFlags.UI.RouterTest do
   end
 
 
-  describe "gates with '/' in the for value" do
-    # Actor ids and group names are free-text input through the admin form and
-    # only filter `?` via Utils.validate/1, so they can legitimately contain `/`.
-
-    setup do
+  describe "PATCH /flags/:name/actors/:actor_id" do
+    test "with an actor id containing '/', it toggles the gate and redirects with an encoded id" do
       {:ok, true} = FunWithFlags.enable(:test_flag_one)
-      :ok
-    end
-
-    test "PATCH /flags/:name/actors/<encoded> toggles the actor gate and redirects with an encoded actor id" do
       {:ok, true} =
         FunWithFlags.enable(:test_flag_one, for_actor: %FunWithFlags.UI.SimpleActor{id: "w:foo/bar"})
 
@@ -224,8 +217,12 @@ defmodule FunWithFlags.UI.RouterTest do
       assert 302 = conn.status
       assert ["/flags/test_flag_one#actor_w%3Afoo%2Fbar"] = get_resp_header(conn, "location")
     end
+  end
 
-    test "DELETE /flags/:name/actors/<encoded> clears the actor gate and redirects" do
+
+  describe "DELETE /flags/:name/actors/:actor_id" do
+    test "with an actor id containing '/', it clears the gate and redirects" do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one)
       {:ok, true} =
         FunWithFlags.enable(:test_flag_one, for_actor: %FunWithFlags.UI.SimpleActor{id: "w:foo/bar"})
 
@@ -239,8 +236,12 @@ defmodule FunWithFlags.UI.RouterTest do
       assert 302 = conn.status
       assert ["/flags/test_flag_one#actor_gates"] = get_resp_header(conn, "location")
     end
+  end
 
-    test "PATCH /flags/:name/groups/<encoded> toggles the group gate and redirects with an encoded group name" do
+
+  describe "PATCH /flags/:name/groups/:group_name" do
+    test "with a group name containing '/', it toggles the gate and redirects with an encoded name" do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one)
       {:ok, true} = FunWithFlags.enable(:test_flag_one, for_group: "tenants/eu")
 
       conn =
@@ -254,8 +255,12 @@ defmodule FunWithFlags.UI.RouterTest do
       assert 302 = conn.status
       assert ["/flags/test_flag_one#group_tenants%2Feu"] = get_resp_header(conn, "location")
     end
+  end
 
-    test "DELETE /flags/:name/groups/<encoded> clears the group gate and redirects" do
+
+  describe "DELETE /flags/:name/groups/:group_name" do
+    test "with a group name containing '/', it clears the gate and redirects" do
+      {:ok, true} = FunWithFlags.enable(:test_flag_one)
       {:ok, true} = FunWithFlags.enable(:test_flag_one, for_group: "tenants/eu")
 
       conn =

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -161,28 +161,6 @@ defmodule FunWithFlags.UI.TemplatesTest do
   end
 
 
-  describe "url_safe/1" do
-    test "percent-encodes slashes" do
-      assert Templates.url_safe("feature/foo") == "feature%2Ffoo"
-    end
-
-    test "percent-encodes URL-reserved characters that would otherwise break routing" do
-      assert Templates.url_safe("a?b") == "a%3Fb"
-      assert Templates.url_safe("a#b") == "a%23b"
-      assert Templates.url_safe("a b") == "a%20b"
-      assert Templates.url_safe("a:b") == "a%3Ab"
-    end
-
-    test "leaves unreserved characters untouched" do
-      assert Templates.url_safe("Normal_name-1.0~final") == "Normal_name-1.0~final"
-    end
-
-    test "accepts atoms" do
-      assert Templates.url_safe(:"feature/foo") == "feature%2Ffoo"
-    end
-  end
-
-
   describe "new()" do
     test "it renders", %{conn: conn} do
       out = Templates.new(conn: conn)

--- a/test/fun_with_flags/ui/templates_test.exs
+++ b/test/fun_with_flags/ui/templates_test.exs
@@ -139,7 +139,7 @@ defmodule FunWithFlags.UI.TemplatesTest do
       out = Templates.details(conn: conn, flag: flag)
 
       assert String.contains?(out, ~s{<div id="actor_moss:123"})
-      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:123" method="post"})
+      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss%3A123" method="post"})
 
       assert String.contains?(out, ~s{<div id="group_rocks"})
       assert String.contains?(out, ~s{<form action="/pear/flags/avocado/groups/rocks" method="post"})
@@ -153,10 +153,32 @@ defmodule FunWithFlags.UI.TemplatesTest do
       out = Templates.details(conn: conn, flag: flag)
 
       assert String.contains?(out, ~s{<div id="actor_moss:&lt;h1&gt;123&lt;/h1&gt;"})
-      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss:%3Ch1%3E123%3C/h1%3E" method="post"})
+      assert String.contains?(out, ~s{<form action="/pear/flags/avocado/actors/moss%3A%3Ch1%3E123%3C%2Fh1%3E" method="post"})
 
       assert String.contains?(out, ~s{<div id="group_rocks"})
       assert String.contains?(out, ~s{<form action="/pear/flags/avocado/groups/rocks" method="post"})
+    end
+  end
+
+
+  describe "url_safe/1" do
+    test "percent-encodes slashes" do
+      assert Templates.url_safe("feature/foo") == "feature%2Ffoo"
+    end
+
+    test "percent-encodes URL-reserved characters that would otherwise break routing" do
+      assert Templates.url_safe("a?b") == "a%3Fb"
+      assert Templates.url_safe("a#b") == "a%23b"
+      assert Templates.url_safe("a b") == "a%20b"
+      assert Templates.url_safe("a:b") == "a%3Ab"
+    end
+
+    test "leaves unreserved characters untouched" do
+      assert Templates.url_safe("Normal_name-1.0~final") == "Normal_name-1.0~final"
+    end
+
+    test "accepts atoms" do
+      assert Templates.url_safe(:"feature/foo") == "feature%2Ffoo"
     end
   end
 

--- a/test/fun_with_flags/ui/utils_test.exs
+++ b/test/fun_with_flags/ui/utils_test.exs
@@ -201,6 +201,28 @@ defmodule FunWithFlags.UI.UtilsTest do
   end
 
 
+  describe "url_safe(value)" do
+    test "percent-encodes slashes" do
+      assert "feature%2Ffoo" = Utils.url_safe("feature/foo")
+    end
+
+    test "percent-encodes reserved characters" do
+      assert "a%3Fb" = Utils.url_safe("a?b")
+      assert "a%23b" = Utils.url_safe("a#b")
+      assert "a%20b" = Utils.url_safe("a b")
+      assert "a%3Ab" = Utils.url_safe("a:b")
+    end
+
+    test "leaves unreserved characters untouched" do
+      assert "Normal_name-1.0~final" = Utils.url_safe("Normal_name-1.0~final")
+    end
+
+    test "accepts atoms" do
+      assert "feature%2Ffoo" = Utils.url_safe(:"feature/foo")
+    end
+  end
+
+
   describe "sanitize(name)" do
     test "it removes leading and trailing whitespace" do
       assert "apricot" = Utils.sanitize(" apricot   ")


### PR DESCRIPTION
Fixes #53.

## Why

Actor IDs and group names are free-text input in the admin UI (`Utils.validate/1` only rejects blank and `?`), so operators can legitimately create gates with values like `w:foo/bar` or `tenants/eu`. Once created, every toggle and clear action on these gates returns 404 because the literal `/` in the rendered URL gets split into extra path segments by the HTTP adapter, and `Plug.Router`'s single-segment `:actor_id` / `:group_name` params can't match.

## What changed

- Tightened `Templates.url_safe/1` to percent-encode all non-unreserved chars (including `/`)
- Added `encode_segment/1` in `Router` to wrap the 4 redirect sites that interpolate gate values into Location headers

## Notes

- Flag names are unaffected — already validated to `^\w+$` by `Utils.validate_flag_name/2`, so no encoding needed there
- Percent-encoding is sufficient because Plug's adapters decode per-segment *after* splitting on `/`, so `%2F` survives as a single segment